### PR TITLE
feat: automatically generate redirects for old versions

### DIFF
--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -111,7 +111,7 @@ exports.handler = async (argv) => {
     }
 
     // Prepare redirects
-    const versionsToRedirect = computeVersionsToRedirect(sortSemVer(releasesToDeploy));
+    const versionsToRedirect = computeVersionsToRedirect(sortSemVerAscending(releasesToDeploy));
 
     // First rendering ot the site
     let vars = processSources(sourceDir, outputDir, siteUrl, {latest, compatibility, releasesToDeploy, versionsToRedirect}, watch, port, liveReloadPort);
@@ -247,7 +247,7 @@ function processSources(sourceDir, outputDir, siteUrl, {latest, compatibility, r
  * Get unique version on Api to deploy. Sorted in descending order.
  */
 function getApiVersionsSortedToDeploy(compatibility) {
-    return [...new Set(compatibility.map(item => item.apiVersions).flat())].sort().reverse();
+    return sortSemVerAscending([...new Set(compatibility.map(item => item.apiVersions).flat())]).reverse();
 }
 
 exports.getApiVersionsSortedToDeploy = getApiVersionsSortedToDeploy;
@@ -282,7 +282,7 @@ exports.computeVersionsToRedirect = computeVersionsToRedirect;
 /**
  * Sorts an array of semantic version strings in ascending order.
  */
-function sortSemVer(versions) {
+function sortSemVerAscending(versions) {
     return versions.sort((a, b) => {
         const [majorA, minorA, patchA] = a.split('.').map(Number);
         const [majorB, minorB, patchB] = b.split('.').map(Number);
@@ -302,7 +302,7 @@ function sortSemVer(versions) {
     });
 }
 
-exports.sortSemVer = sortSemVer;
+exports.sortSemVer = sortSemVerAscending;
 
 
 async function downloadRelease(downloadUrlTemplate, outputDirectory, releaseVersion, latest) {

--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -66,8 +66,12 @@ exports.builder = (yargs) => {
         }
     }).check((argv) => {
         const releases = getApiVersionsSortedToDeploy(argv.compatibility);
+        logger.debug(`Releases to deploy: ${releases}`);
         if (releases.length === 1) {
             argv.latest = releases[0]
+        } else if (argv.latest === undefined) {
+            argv.latest = releases[0]
+            logger.debug(`No latest release specified, using the latest release from the releases to deploy: ${argv.latest}`);
         }
         const latest = argv.latest
         if (!releases.includes(latest)) {
@@ -239,8 +243,8 @@ function processSources(sourceDir, outputDir, siteUrl, {latest, compatibility, r
 }
 
 
-/*
- ** Get unique version on Api to deploy
+/**
+ * Get unique version on Api to deploy. Sorted in descending order.
  */
 function getApiVersionsSortedToDeploy(compatibility) {
     return [...new Set(compatibility.map(item => item.apiVersions).flat())].sort().reverse();

--- a/cli/restdoc-site.cfg.json
+++ b/cli/restdoc-site.cfg.json
@@ -1,7 +1,6 @@
 {
   "sourceDir": "./site",
   "downloadUrlTemplate": "https://github.com/bonitasoft/bonita-openapi/releases/download/${releaseVersion}/bonita-openapi-${releaseVersion}.zip",
-  "latest": "1.0.5",
   "compatibility": [
     {
       "bonita": "2025.1",

--- a/cli/tests/build.test.js
+++ b/cli/tests/build.test.js
@@ -1,68 +1,115 @@
-const {getApiVersionsSortedToDeploy} = require('../commands/build.js');
+const {computeVersionsToRedirect, getApiVersionsSortedToDeploy, sortSemVer} = require('../commands/build.js');
 
+describe('getApiVersionsSortedToDeploy', () => {
+    test('should return an unique api version', () => {
+        const releases = [
+            {
+                "bonita": "2021.1",
+                "apiVersions": [
+                    "0.0.11"
+                ],
+                "bonitaSemver": "7.12.x"
+            }
+        ];
+        expect(getApiVersionsSortedToDeploy(releases)).toStrictEqual(['0.0.11']);
+    });
 
-test('should return an unique api version', () => {
-    const releases = [
-        {
-            "bonita": "2021.1",
-            "apiVersions": [
-                "0.0.11"
-            ],
-            "bonitaSemver": "7.12.x"
-        }
-    ];
-    expect(getApiVersionsSortedToDeploy(releases)).toStrictEqual(['0.0.11']);
+    test('should return two version without duplicate when duplicate in apiVersion is given', () => {
+        const releases = [
+            {
+                "bonita": "2021.1",
+                "apiVersions": [
+                    "0.0.11"
+                ],
+                "bonitaSemver": "7.12.x"
+            },
+            {
+                "bonita": "2021.2",
+                "apiVersions": [
+                    "0.0.11", "0.0.12"
+                ],
+                "bonitaSemver": "7.12.x"
+            }
+        ];
+        expect(getApiVersionsSortedToDeploy(releases)).toStrictEqual(['0.0.12', '0.0.11']);
+    });
+
+    test('should return only one deployed version ', () => {
+        const releases = [
+            {
+                "bonita": "2021.1",
+                "apiVersions": [
+                    "0.0.11"
+                ],
+                "bonitaSemver": "7.12.x"
+            },
+            {
+                "bonita": "2021.2",
+                "apiVersions": [
+                    "0.0.11"
+                ],
+                "bonitaSemver": "7.13.x"
+            },
+            {
+                "bonita": "2022.1",
+                "apiVersions": [
+                    "0.0.11"
+                ],
+                "bonitaSemver": "7.14.x"
+            },
+            {
+                "bonita": "2022.2",
+                "apiVersions": [
+                    "0.0.11"
+                ],
+                "bonitaSemver": "7.15.x"
+            }
+        ]
+        expect(getApiVersionsSortedToDeploy(releases)).toStrictEqual(['0.0.11']);
+    });
 });
 
-test('should return two version without duplicate when duplicate in apiVersion is given', () => {
-    const releases = [
-        {
-            "bonita": "2021.1",
-            "apiVersions": [
-                "0.0.11"
-            ],
-            "bonitaSemver": "7.12.x"
-        },
-        {
-            "bonita": "2021.2",
-            "apiVersions": [
-                "0.0.11", "0.0.12"
-            ],
-            "bonitaSemver": "7.12.x"
-        }
-    ];
-    expect(getApiVersionsSortedToDeploy(releases)).toStrictEqual(['0.0.12', '0.0.11']);
+describe('sortSemVer', () => {
+    test('should sort versions that only differ on patch', () => {
+        expect(sortSemVer(['0.0.8', '0.0.4', '0.0.1'])).toStrictEqual(['0.0.1', '0.0.4', '0.0.8']);
+    });
+
+    test('should sort versions from various major and minor', () => {
+        expect(sortSemVer(['1.3.56', '3.1.4', '1.3.8', '0.4.8', '0.0.17'])).toStrictEqual(['0.0.17', '0.4.8', '1.3.8', '1.3.56', '3.1.4']);
+    });
+
 });
-test('should return only one deployed version ', () => {
-    const releases = [
-        {
-            "bonita": "2021.1",
-            "apiVersions": [
-                "0.0.11"
-            ],
-            "bonitaSemver": "7.12.x"
-        },
-        {
-            "bonita": "2021.2",
-            "apiVersions": [
-                "0.0.11"
-            ],
-            "bonitaSemver": "7.13.x"
-        },
-        {
-            "bonita": "2022.1",
-            "apiVersions": [
-                "0.0.11"
-            ],
-            "bonitaSemver": "7.14.x"
-        },
-        {
-            "bonita": "2022.2",
-            "apiVersions": [
-                "0.0.11"
-            ],
-            "bonitaSemver": "7.15.x"
-        }
-    ]
-    expect(getApiVersionsSortedToDeploy(releases)).toStrictEqual(['0.0.11']);
+
+describe('computeVersionsToRedirect', () => {
+    test('should return a single property when passing a single version ', () => {
+        expect(computeVersionsToRedirect(['0.0.4'])).toStrictEqual({
+            '0.0.4': ['0.0.1', '0.0.2', '0.0.3']
+        });
+    });
+
+    test('should return empty object when single version with patch is zero', () => {
+        expect(computeVersionsToRedirect(['2.1.0'])).toStrictEqual({});
+    });
+
+    test('should return two properties when passing two versions with the same major/minor', () => {
+        expect(computeVersionsToRedirect(['0.0.4', '0.0.7'])).toStrictEqual({
+            '0.0.4': ['0.0.1', '0.0.2', '0.0.3'],
+            '0.0.7': ['0.0.5', '0.0.6']
+        });
+    });
+
+    test('should return two properties when passing two versions with the same major but different minor', () => {
+        expect(computeVersionsToRedirect(['1.1.4', '1.3.3'])).toStrictEqual({
+            '1.1.4': ['1.1.0', '1.1.1', '1.1.2', '1.1.3'],
+            '1.3.3': ['1.3.0', '1.3.1', '1.3.2']
+        });
+    });
+
+    test('should return two properties when passing two versions with the same minor but different major', () => {
+        expect(computeVersionsToRedirect(['1.1.4', '3.1.3'])).toStrictEqual({
+            '1.1.4': ['1.1.0', '1.1.1', '1.1.2', '1.1.3'],
+            '3.1.3': ['3.1.0', '3.1.1', '3.1.2']
+        });
+    });
+
 });

--- a/cli/tests/build.test.js
+++ b/cli/tests/build.test.js
@@ -14,12 +14,12 @@ describe('getApiVersionsSortedToDeploy', () => {
         expect(getApiVersionsSortedToDeploy(releases)).toStrictEqual(['0.0.11']);
     });
 
-    test('should return two version without duplicate when duplicate in apiVersion is given', () => {
+    test('should return versions without duplicate when duplicate in apiVersion is given', () => {
         const releases = [
             {
                 "bonita": "2021.1",
                 "apiVersions": [
-                    "0.0.11"
+                    "0.0.3", "0.0.2"
                 ],
                 "bonitaSemver": "7.12.x"
             },
@@ -29,9 +29,16 @@ describe('getApiVersionsSortedToDeploy', () => {
                     "0.0.11", "0.0.12"
                 ],
                 "bonitaSemver": "7.12.x"
+            },
+            {
+                "bonita": "2021.3",
+                "apiVersions": [
+                    "0.0.11", "0.0.12"
+                ],
+                "bonitaSemver": "7.12.x"
             }
         ];
-        expect(getApiVersionsSortedToDeploy(releases)).toStrictEqual(['0.0.12', '0.0.11']);
+        expect(getApiVersionsSortedToDeploy(releases)).toStrictEqual(['0.0.12', '0.0.11', '0.0.3', '0.0.2']);
     });
 
     test('should return only one deployed version ', () => {
@@ -71,11 +78,11 @@ describe('getApiVersionsSortedToDeploy', () => {
 
 describe('sortSemVer', () => {
     test('should sort versions that only differ on patch', () => {
-        expect(sortSemVer(['0.0.8', '0.0.4', '0.0.1'])).toStrictEqual(['0.0.1', '0.0.4', '0.0.8']);
+        expect(sortSemVer(['0.0.8', '0.0.4', '0.0.25', '0.0.1'])).toStrictEqual(['0.0.1', '0.0.4', '0.0.8', '0.0.25']);
     });
 
     test('should sort versions from various major and minor', () => {
-        expect(sortSemVer(['1.3.56', '3.1.4', '1.3.8', '0.4.8', '0.0.17'])).toStrictEqual(['0.0.17', '0.4.8', '1.3.8', '1.3.56', '3.1.4']);
+        expect(sortSemVer(['1.3.56', '3.1.4', '1.3.8', '0.4.8', '0.0.17', '1.3.22'])).toStrictEqual(['0.0.17', '0.4.8', '1.3.8', '1.3.22', '1.3.56', '3.1.4']);
     });
 
 });

--- a/site/templates/netlify.toml.hbs
+++ b/site/templates/netlify.toml.hbs
@@ -6,28 +6,23 @@ to = "https://api-documentation.bonitasoft.com/:splat"
 force = true
 
 ########################################################################################################################
-# Bonita open-api redirect
+# Bonita open-api redirects
 ########################################################################################################################
 
-# Old 1.0.x redirects. In the future, this could be automatically generated from the `cli/restdoc-site.cfg.json` file.
+# Redirects the intermediate versions that are no longer available to the closed version available on the site.
+{{#each versionsToRedirect}}
+{{#each this}}
 [[redirects]]
-from = "/1.0.0/*"
-to = "/latest/:splat"
-[[redirects]]
-from = "/1.0.1/*"
-to = "/latest/:splat"
-[[redirects]]
-from = "/1.0.2/*"
-to = "/latest/:splat"
-[[redirects]]
-from = "/1.0.3/*"
-to = "/latest/:splat"
-[[redirects]]
-from = "/1.0.4/*"
-to = "/latest/:splat"
+from = "/{{this}}/*"
+to = "/{{@../key}}/:splat"
+{{/each}}
+
+{{/each}}
 
 # latest
 [[redirects]]
 from = "/{{latest}}/*"
 to = "/latest/:splat"
+# the latest version changes over time
+status = 302
 

--- a/site/templates/netlify.toml.hbs
+++ b/site/templates/netlify.toml.hbs
@@ -11,6 +11,7 @@ force = true
 
 # Redirects the intermediate versions that are no longer available to the closed version available on the site.
 {{#each versionsToRedirect}}
+# Redirects to {{@key}}
 {{#each this}}
 [[redirects]]
 from = "/{{this}}/*"


### PR DESCRIPTION
This prevents users from getting HTTP 404 errors. Previously, this had to be handled manually, and most of the time, it wasn't done.

Assuming versions 0.0.12, 0.26.0 and 1.0.4 are present, the following redirects are generated:
  - 0.0.1 or 0.0.7: 0.0.12
  - 0.18.0 or 0.21.3: 0.26.0
  - 1.0.0 or 1.0.2: 1.0.4

Also make the latest attribute optional in the configuration (fallback to the greater version).
Fix "version to deploy" sort: it was using text sort instead of semver sort

### Notes

Examples of generated toml file with the current configuration

```toml
# Redirects the intermediate versions that are no longer available to the closed version available on the site.
# Redirects to 0.0.16
[[redirects]]
from = "/0.0.1/*"
to = "/0.0.16/:splat"
[[redirects]]
from = "/0.0.2/*"
to = "/0.0.16/:splat"
[[redirects]]
from = "/0.0.3/*"
to = "/0.0.16/:splat"
[[redirects]]
from = "/0.0.4/*"
to = "/0.0.16/:splat"
[[redirects]]
from = "/0.0.5/*"
to = "/0.0.16/:splat"
[[redirects]]
from = "/0.0.6/*"
to = "/0.0.16/:splat"
[[redirects]]
from = "/0.0.7/*"
to = "/0.0.16/:splat"
[[redirects]]
from = "/0.0.8/*"
to = "/0.0.16/:splat"
[[redirects]]
from = "/0.0.9/*"
to = "/0.0.16/:splat"
[[redirects]]
from = "/0.0.10/*"
to = "/0.0.16/:splat"
[[redirects]]
from = "/0.0.11/*"
to = "/0.0.16/:splat"
[[redirects]]
from = "/0.0.12/*"
to = "/0.0.16/:splat"
[[redirects]]
from = "/0.0.13/*"
to = "/0.0.16/:splat"
[[redirects]]
from = "/0.0.14/*"
to = "/0.0.16/:splat"
[[redirects]]
from = "/0.0.15/*"
to = "/0.0.16/:splat"

# Redirects to 0.0.21
[[redirects]]
from = "/0.0.17/*"
to = "/0.0.21/:splat"
[[redirects]]
from = "/0.0.18/*"
to = "/0.0.21/:splat"
[[redirects]]
from = "/0.0.19/*"
to = "/0.0.21/:splat"
[[redirects]]
from = "/0.0.20/*"
to = "/0.0.21/:splat"

# Redirects to 1.0.5
[[redirects]]
from = "/1.0.0/*"
to = "/1.0.5/:splat"
[[redirects]]
from = "/1.0.1/*"
to = "/1.0.5/:splat"
[[redirects]]
from = "/1.0.2/*"
to = "/1.0.5/:splat"
[[redirects]]
from = "/1.0.3/*"
to = "/1.0.5/:splat"
[[redirects]]
from = "/1.0.4/*"
to = "/1.0.5/:splat"


# latest
[[redirects]]
from = "/1.0.5/*"
to = "/latest/:splat"
# the latest version changes over time
status = 302
```